### PR TITLE
Update Intel experience, wordcloud, and submitted papers

### DIFF
--- a/CV.bib
+++ b/CV.bib
@@ -88,12 +88,25 @@ McAlpin and L. Pettey and Gajanan Krishna Choudhary and C.N. Dawson",
   keywords = "article",
 }
 
-@article{bib:choudhary21SW2D3DPaper,
-  title = "Strongly coupled 2{D} and 3{D} shallow water models for simulation of baroclinic flows involving wetting-drying",
-  journal = "In draft",
-  year = "2021",
+@article{bib:choudhary21SW2D3DPaperPart1,
+  title = "Strongly coupled 2{D} and 3{D} shallow water models {I}: theory and verification",
+  journal = "Journal of Hydraulic Engineering",
+  pages = "Under review",
+  year = "2023",
   author = "Gajanan Krishna Choudhary and Trahan, C. J. and Pettey, L. and
-            Farthing, M. and Inanc, E. and Savant, G. and Dawson, C.",
+            Farthing, M. and Berger, C. and Savant, G. and Inanc, E. and
+            Dawson, C. and Loveland, M. D.",
+  keywords = "article",
+}
+
+@article{bib:choudhary21SW2D3DPaperPart2,
+  title = "Strongly coupled 2{D} and 3{D} shallow water models {II}: validation and applications",
+  journal = "Journal of Hydraulic Engineering",
+  year = "2023",
+  pages = "Under review",
+  author = "Gajanan Krishna Choudhary and Trahan, C. J. and Pettey, L. and
+            Farthing, M. and Berger, C. and Savant, G. and Inanc, E. and
+            Dawson, C. and Loveland, M. D.",
   keywords = "article",
 }
 

--- a/CV.tex
+++ b/CV.tex
@@ -400,7 +400,7 @@ published technical documents.
       %-------------------------------Job 3------------------------------------%
       \resumeSubSubheading{\textbf{The University of Texas at Austin}}{Austin, TX}
         \resumeItemListStart
-          \resumeUnlabeledItem{Mentored a female undergraduate student at UT
+          \resumeUnlabeledItem{Mentored an undergraduate student at UT
             Austin in Spring '18 in support of the Women in Engineering
             Program's mission of inspiring women to pursue graduate degrees in
             STEM.}

--- a/CV.tex
+++ b/CV.tex
@@ -29,13 +29,13 @@
 
 %------------------------------------SUMMARY-----------------------------------%
 \section{Summary}
-Software engineer and computational scientist with 8 years of
-inter-disciplinary research and software development experience through
-15\smallplus{} projects spanning high-performance computing (HPC), applied
-mathematics, numerical methods, computational mechanics, optimization, and
-machine learning. Creator of 4 scientific software, contributor to 4 HPC
-software written in C, \CC{}, DP\CC{}, Python, and Fortran, and author of 5
-published technical documents.
+Computational scientist and software engineer with over 10 years of
+inter-disciplinary research and software development experience spanning
+high-performance computing (HPC), applied mathematics, computational
+mechanics, performance optimization, and machine learning. Creator of 4
+scientific software, contributor to 5 HPC software written in C, \CC{},
+SYCL/DP\CC{}, Python, and Fortran, and author of 5 published technical
+documents.
 %% \\[1\baselineskip] added above since \parbox{0.546\linewidth}{\section{Summary}}
 %% messes up line spacing in the new section causing overlapping lines.
 
@@ -147,16 +147,22 @@ published technical documents.
       %-------------------------------Job 5------------------------------------%
       \resumeSubSubheading{\textbf{Intel Corporation}}{Austin, TX}
         \resumeItemListStart
-          \resumeUnlabeledItem{Owned sparse linear algebra and sparse solver
-            components as a contributor in the
-            Intel\textsuperscript{\scriptsize{\textregistered}} oneAPI Math
+          \resumeUnlabeledItem{Owned sparse linear algebra and high-performance
+            conjugate gradient (HPCG) benchmark components as a contributor in
+            the Intel\textsuperscript{\scriptsize{\textregistered}} oneAPI Math
             Kernel Library (oneMKL) team.}
-          \resumeUnlabeledItem{Implemented GPU performance optimizations for the
-            newly introduced DP\CC{} API of sparse $\times$ sparse matrix
-            product for compressed sparse row (CSR) matrices in oneMKL.}
+          \resumeUnlabeledItem{Doubled the performance of sparse matrix-vector
+            product (GEMV) oneMKL SYCL API on latest Intel GPUs using SIMD
+            vectorization and prefetching techniques.}
+          \resumeUnlabeledItem{Implemented GPU performance optimizations for
+            the newly introduced sparse $\times$ sparse matrix product
+            (matmat/spGEMM) SYCL API for compressed sparse row (CSR) matrices
+            in oneMKL.}
           \resumeUnlabeledItem{Doubled the performance of block sparse row (BSR)
             matrix $\times$ row-major dense matrix product in oneMKL on CPUs
-            by implementing loop unrolling and AVX2/AVX512 compiler intrinsics.}
+            by using AVX512 compiler intrinsics.}
+          \resumeUnlabeledItem{Introduced optimized SYCL APIs in oneMKL
+            for sorting, copying and transposing CSR matrices on GPUs.}
         \resumeItemListEnd
 
     %---------------------------------Title------------------------------------%
@@ -213,9 +219,9 @@ published technical documents.
             flooding with 3D ocean models.}
           \resumeUnlabeledItem{Created the open-source C software,
             AdH-meshbuilder, for generating arrays of coupled AdH models.}
-          \resumeUnlabeledItem{Contributed numerous physics modules to AdH for
-            USACE, including its wind library, 3D prism mesh adaption, and
-            improved parallel load rebalancing for 3D models.}
+          \resumeUnlabeledItem{Developed important physics features in AdH
+            for USACE, including its wind library, 3D prism mesh adaption,
+            and improved parallel load rebalancing in 3D models.}
        \resumeItemListEnd
 
     %---------------------------------Title------------------------------------%
@@ -244,10 +250,10 @@ published technical documents.
 \section{Software Contributions}
   \resumeSubItemListStart
     \resumeSubItem{Contributor -- \href{https://https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html}{Intel\textsuperscript{\scriptsize{\textregistered}} oneAPI Math Kernel Library (oneMKL)}}
-      {Owned feature implementations, CPU/GPU architecture-specific performance
-       optimizations, and bug fixes for sparse linear algebra and sparse solver
+      {Owned feature implementations and CPU/GPU architecture-specific
+       performance optimizations for sparse linear algebra and HPCG benchmark
        components in oneMKL, written in \textbf{C}, \textbf{\CC{}},
-       \textbf{DP\CC{}}, and \textbf{Fortran}.}
+       \textbf{SYCL/DP\CC{}}, and \textbf{Fortran}.}
     \resumeSubItem{Creator -- \href{https://github.com/gajanan-choudhary/water-coupler}{Water Coupler}}
       {Developed the \textbf{open-source parallel Python} software for coupling
       physics models, AdH (\textbf{C}), GSSHA (\textbf{\CC{}}), and ADCIRC
@@ -284,8 +290,8 @@ published technical documents.
 
     \resumeSubheading{Software development:}{}
       \resumeItemListStart
-        \resumeItem{Programming}{C/\CC{}, DP\CC{}, Python, Fortran, MATLAB,
-            SYCL, MPI, OpenMP, f2py, SWIG, Python/C API, and Bash.}
+        \resumeItem{Programming}{C/\CC{}, SYCL/DP\CC{}, Python, Fortran,
+            MATLAB, MPI, OpenMP, f2py, SWIG, Python/C API, and Bash.}
 
         \resumeItem{Tools}{GitHub, Bitbucket, Git, Mercurial, SVN,
             Travis CI, CircleCI, Docker, Coveralls, Codecov, CMake, GNU Make,
@@ -294,8 +300,8 @@ published technical documents.
 
         \resumeItem{Concepts}{Data structures, algorithms, complexity,
             object-oriented programming (OOP), standard template library (STL),
-            high-performance computing, parallel programming, debugging, general
-            purpose GPU (GPGPU) programming, language interoperability,
+            high-performance computing, parallel programming, CPU and GPU
+            performance optimization, language interoperability, debugging,
             continuous integration and continuous delivery (CI/CD), and
             test-driven development (TDD).}
       \resumeItemListEnd

--- a/CV.tex
+++ b/CV.tex
@@ -50,45 +50,49 @@ documents.
 
     \begin{tinyb}
 
-      \node[color=uto]at (0.26,0.13){\footnotesize ANSYS\space };
-      
-      \node[color=uto]at (0.57,0.25){\tiny CSS\space };
+      \node[color=utg]at (0.20,0.13){\footnotesize Assembly\space };
+
+      \node[color=uto]at (0.10,0.20){\tiny Kernels\space };
+
+      \node[color=uto]at (0.57,0.25){\tiny Docker\space };
 
       \node[color=utg]at (0.17,0.34){\Large Python\space };
 
-      \node[color=uto]at (0.38,0.45){\scriptsize Matplotlib\space };
+      \node[color=uto]at (0.46,0.45){\scriptsize Sparse BLAS\space };
 
-      \node[color=utg]at (0.42,0.58){\normalsize MPI\space };
+      \node[color=utg]at (0.08,0.51){\footnotesize ANSYS\space };
 
-      \node[color=uto]at (0.29,0.88){\footnotesize Abaqus\space };
+      \node[color=utg]at (0.47,0.61){\normalsize MPI\space };
+
+      \node[color=uto]at (0.09,0.92){\scriptsize Intel Corporation\space };
 
       \node[color=utg]at (0.12,1.03){\footnotesize SWIG\space };
 
       \node[color=uto]at (0.16,1.18){\small CMake\space };
 
-      \node[color=uto]at (0.75,0.19){\normalsize Docker\space };
+      \node[color=uto]at (0.78,0.17){\large SYCL\space };
 
-      \node[color=utg]at (0.85,0.43){\footnotesize Bash\space };
+      \node[color=utg]at (0.85,0.32){\tiny GPUs\space };
 
       \node[color=uto]at (0.79,0.57){\footnotesize ctypes\space };
 
-      \node[color=utg]at (0.77,0.89){\footnotesize IIT Kharagpur\space };
+      \node[color=utg]at (0.85,0.89){\footnotesize IIT Kharagpur\space };
 
       \node[color=uto]at (0.50,1.03){\large CircleCI\space };
 
       \node[color=utg]at (0.65,1.17){\normalsize Neural Networks\space };
 
-      \node[color=uto]at (1.24,0.14){\footnotesize Image Processing\space };
+      \node[color=uto]at (1.28,0.14){\footnotesize Image Processing\space };
+
+      \node[color=utg]at (1.25,0.22){\tiny Performance optimization\space };
 
       \node[color=uto]at (1.07,0.35){\large GitHub\space };
 
-      \node[color=utg]at (1.15,0.50){\scriptsize SVN\space };
+      \node[color=utg]at (1.10,0.50){\scriptsize HPCG\space };
 
       \node[color=uto]at (1.18,1.01){\footnotesize MATLAB\space };
 
-      \node[color=uto]at (1.31,1.11){\tiny HTML\space };
-
-      \node[color=utg]at (1.51,0.22){\tiny STAAD Pro\space };
+      \node[color=uto]at (1.31,1.11){\tiny Bash\space };
 
       \node[color=utg]at (1.66,0.32){\footnotesize Coveralls\space };
 
@@ -96,29 +100,31 @@ documents.
 
       \node[color=utg]at (1.36,0.61){\small Fortran\space };
 
-      \node[color=uto]at (1.70,0.92){\normalsize AdH\space };
-      
+      \node[color=utg]at (1.60,0.87){\tiny CPUs\space };
+
+      \node[color=uto]at (1.77,0.92){\normalsize AdH\space };
+
       \node[color=utg]at (1.73,1.06){\small f2py\space };
 
       \node[color=uto]at (1.76,1.18){\scriptsize ParaView\space };
 
-      \node[color=uto]at (1.99,0.23){\scriptsize Make\space };
-
-      \node[color=uto]at (1.93,0.48){\normalsize Finite Elements\space };
-
-      \node[color=utg]at (2.05,1.03){\huge C/\bigCC{}\space };
-
       \node[color=utg]at (2.20,0.12){\footnotesize OpenMP\space };
+
+      \node[color=uto]at (2.08,0.23){\scriptsize Make\space };
 
       \node[color=uto]at (2.39,0.21){\scriptsize UT Austin\space };
 
       \node[color=utg]at (2.16,0.32){\small Travis CI\space };
 
-      \node[color=utg]at (2.49,0.42){\tiny AutoCAD\space };
+      \node[color=utg]at (2.33,0.40){\tiny Compiler Intrinsics\space };
+
+      \node[color=uto]at (1.93,0.50){\normalsize Applied Math\space };
 
       \node[color=utg]at (2.26,0.61){\scriptsize ERDC\space };
 
       \node[color=uto]at (2.65,0.90){\scriptsize Git\space };
+
+      \node[color=utg]at (2.05,1.03){\huge C/\bigCC{}\space };
 
       \node[color=uto]at (2.40,1.19){\scriptsize SMS/WMS\space };
 

--- a/README.md
+++ b/README.md
@@ -232,9 +232,16 @@ Supervisors: Dr. N. Mitra and Dr. S. K. Barai.
   for simulation of compound floods. In draft.
 
 * Choudhary, G. K., Trahan, C. J., Pettey, L., Farthing, M.,
-  Inanc, E., Savant, G., & Dawson, C. Strongly coupled 2D and 3D
-  shallow water models for simulation of baroclinic flows
-  involving wetting and drying. In draft.
+  Berger, C., Savant, G., Inanc, E., Dawson, C. & Loveland, M. D.
+  Strongly coupled 2D and 3D shallow water models I: theory and
+  verification. Journal of Hydraulic Engineering. Submitted and
+  under review.
+
+* Choudhary, G. K., Trahan, C. J., Pettey, L., Farthing, M.,
+  Berger, C., Savant, G., Inanc, E., Dawson, C. & Loveland, M. D.
+  Strongly coupled 2D and 3D shallow water models II: validation
+  and applications. Journal of Hydraulic Engineering. Submitted
+  and under review.
 
 * Trahan, C. J., Savant, G., Berger, R. C., McAlpin, T. O.,
   Pettey, L., Choudhary, G. K., & Dawson, C. N. (2018).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gajanan Choudhary
 
-Address: Lake Austin Blvd., Austin, TX 78703
+Address: Austin, TX, USA
 
 Phone: (512) 657-3030
 

--- a/README.md
+++ b/README.md
@@ -14,29 +14,28 @@ GitHub: http://github.com/gajanan-choudhary
 
 
 ## Summary
-Software engineer and computational scientist with 8 years of
-inter-disciplinary research and software development experience through
-15+ projects spanning high-performance computing (HPC), applied
-mathematics, numerical methods, computational mechanics, optimization, and
-machine learning. Creator of 4 scientific software, contributor to 4 HPC
-software written in C, C++, DPC++, Python, and Fortran, and author of 5
-published technical documents.
-
+Computational scientist and software engineer with over 10 years of
+inter-disciplinary research and software development experience spanning
+high-performance computing (HPC), CPU and GPU performance optimization,
+applied mathematics, numerical methods, computational mechanics, and
+machine learning. Creator of 4 scientific software, contributor to 5 HPC
+software/libraries written in C, C++, SYCL/DPC++, Python, and Fortran,
+and author of 5 published technical documents.
 
 ## Skills
 * Software development:
-    - Programming: C/C++, DPC++, Fortran, Python, MATLAB, SYCL, MPI,
-      OpenMP, f2py, SWIG, and Python/C API, and Bash.
+    - Programming: C/C++, Fortran, Python, MATLAB, SYCL/DPC++, MPI,
+      OpenMP, f2py, SWIG, Python/C API, and Bash.
     - Tools: GitHub, Bitbucket, Git, Mercurial, SVN, Travis CI,
       CircleCI, Docker, Coveralls, Codecov, CMake, GNU Make,
       Gcov, LCOV, GProf, GDB, Valgrind, Doxygen, LaTeX, HTML, and CSS.
     - Concepts: Data structures, algorithms, complexity,
       object-oriented programming (OOP), standard template
-      library (STL), high-performance computing, parallel
-      programming, general purpose GPU (GPGPU) programming,
-      language interoperability, debugging, continuous
-      integration and continuous delivery (CI/CD), and
-      test-driven development (TDD).
+      library (STL), high-performance computing, parallel programming,
+      CPU and GPU performance optimization, compiler intrinsics,
+      assembly, language interoperability, debugging, continuous
+      integration and continuous delivery (CI/CD), and test-driven
+      development (TDD).
 
 * Research:
     - Engineering: Computational mechanics, computational fluid
@@ -53,15 +52,20 @@ published technical documents.
 ## Work Experience
 * Software Engineer, Intel Corporation,
 Austin, TX, February 2021 - Present.
-  - Responsibilities: Owned sparse linear algebra and sparse solver components
-    in the Intel oneAPI Math Kernel Library (oneMKL) team, and optimized their
-    performance on CPUs and GPUs.
-  - Implemented GPU performance optimizations for the
-    newly introduced DPC++ API of sparse &times; sparse matrix
+  - Responsibilities: Owned High-Performance Conjugate Gradient (HPCG)
+    benchmark and sparse BLAS components in the Intel oneAPI Math
+    Kernel Library (oneMKL) team and optimized their performance on latest
+    and upcoming Intel CPUs and GPUs.
+  - Doubled the performance of sparse matrix-vector product (GEMV)
+    on latest Intel GPUs using SIMD vectorization and prefetching techniques.
+  - Implemented GPU performance optimizations for a newly introduced
+    SYCL/DPC++ API, sparse::matmat, for sparse &times; sparse = sparse matrix
     product for compressed sparse row (CSR) matrices in oneMKL.
   - Doubled the performance of block sparse row (BSR)
     matrix &times; column-major dense matrix product in oneMKL on CPUs
-    by implementing loop unrolling and AVX2/AVX512 compiler intrinsics.
+    using AVX512 compiler intrinsics.
+  - Introduced optimized SYCL APIs in oneMKL for sorting, copying and
+    transposing CSR matrices on GPUs.
 
 * Research Associate, The University of Texas at Austin,
 Austin, TX, December 2020 - February 2021.

--- a/README.md
+++ b/README.md
@@ -211,10 +211,10 @@ Supervisors: Dr. N. Mitra and Dr. S. K. Barai.
 
 
 ## Activities
-* Diversity: Mentored a female undergraduate student in Spring
+* Diversity: Mentored an undergraduate student in Spring
   2018 as part of Graduates Linked with Undergraduates in
-  Engineering (GLUE) program at UT Austin, with the aim to
-  inspire women to pursue graduate degrees in STEM.
+  Engineering (GLUE) program at UT Austin, aimed at
+  inspiring women to pursue graduate degrees in STEM.
 
 * Dance: Completed intermediate level training in various social
   dance forms at UT Austin and Austin Swing Syndicate.

--- a/mymacros.tex
+++ b/mymacros.tex
@@ -10,7 +10,7 @@
 
 \def\Author{Gajanan Choudhary}
 \def\AuthorEmail{gajananchoudhary91@gmail.com}
-\def\AuthorAddress{3352 Lake Austin Blvd, Austin, TX 78703, USA}
+\def\AuthorAddress{Austin, TX, USA}
 \def\AuthorPhoneText{\smallplus{}1 (512) 657-3030}
 \def\AuthorPhoneLink{tel:15126573030}
 

--- a/one-page-resume.tex
+++ b/one-page-resume.tex
@@ -61,45 +61,49 @@ documents.
 
     \begin{tinyb}
 
-      \node[color=uto]at (0.26,0.13){\footnotesize ANSYS\space };
-      
-      \node[color=uto]at (0.57,0.25){\tiny CSS\space };
+      \node[color=utg]at (0.20,0.13){\footnotesize Assembly\space };
+
+      \node[color=uto]at (0.10,0.20){\tiny Kernels\space };
+
+      \node[color=uto]at (0.57,0.25){\tiny Docker\space };
 
       \node[color=utg]at (0.17,0.34){\Large Python\space };
 
-      \node[color=uto]at (0.38,0.45){\scriptsize Matplotlib\space };
+      \node[color=uto]at (0.46,0.45){\scriptsize Sparse BLAS\space };
 
-      \node[color=utg]at (0.42,0.58){\normalsize MPI\space };
+      \node[color=utg]at (0.08,0.51){\footnotesize ANSYS\space };
 
-      \node[color=uto]at (0.29,0.88){\footnotesize Abaqus\space };
+      \node[color=utg]at (0.47,0.61){\normalsize MPI\space };
+
+      \node[color=uto]at (0.09,0.92){\scriptsize Intel Corporation\space };
 
       \node[color=utg]at (0.12,1.03){\footnotesize SWIG\space };
 
       \node[color=uto]at (0.16,1.18){\small CMake\space };
 
-      \node[color=uto]at (0.75,0.19){\normalsize Docker\space };
+      \node[color=uto]at (0.78,0.17){\large SYCL\space };
 
-      \node[color=utg]at (0.85,0.43){\footnotesize Bash\space };
+      \node[color=utg]at (0.85,0.32){\tiny GPUs\space };
 
       \node[color=uto]at (0.79,0.57){\footnotesize ctypes\space };
 
-      \node[color=utg]at (0.77,0.89){\footnotesize IIT Kharagpur\space };
+      \node[color=utg]at (0.85,0.89){\footnotesize IIT Kharagpur\space };
 
       \node[color=uto]at (0.50,1.03){\large CircleCI\space };
 
       \node[color=utg]at (0.65,1.17){\normalsize Neural Networks\space };
 
-      \node[color=uto]at (1.24,0.14){\footnotesize Image Processing\space };
+      \node[color=uto]at (1.28,0.14){\footnotesize Image Processing\space };
+
+      \node[color=utg]at (1.25,0.22){\tiny Performance optimization\space };
 
       \node[color=uto]at (1.07,0.35){\large GitHub\space };
 
-      \node[color=utg]at (1.15,0.50){\scriptsize SVN\space };
+      \node[color=utg]at (1.10,0.50){\scriptsize HPCG\space };
 
       \node[color=uto]at (1.18,1.01){\footnotesize MATLAB\space };
 
-      \node[color=uto]at (1.31,1.11){\tiny HTML\space };
-
-      \node[color=utg]at (1.51,0.22){\tiny STAAD Pro\space };
+      \node[color=uto]at (1.31,1.11){\tiny Bash\space };
 
       \node[color=utg]at (1.66,0.32){\footnotesize Coveralls\space };
 
@@ -107,29 +111,31 @@ documents.
 
       \node[color=utg]at (1.36,0.61){\small Fortran\space };
 
-      \node[color=uto]at (1.70,0.92){\normalsize AdH\space };
-      
+      \node[color=utg]at (1.60,0.87){\tiny CPUs\space };
+
+      \node[color=uto]at (1.77,0.92){\normalsize AdH\space };
+
       \node[color=utg]at (1.73,1.06){\small f2py\space };
 
       \node[color=uto]at (1.76,1.18){\scriptsize ParaView\space };
 
-      \node[color=uto]at (1.99,0.23){\scriptsize Make\space };
-
-      \node[color=uto]at (1.93,0.48){\normalsize Finite Elements\space };
-
-      \node[color=utg]at (2.05,1.03){\huge C/\bigCC{}\space };
-
       \node[color=utg]at (2.20,0.12){\footnotesize OpenMP\space };
+
+      \node[color=uto]at (2.08,0.23){\scriptsize Make\space };
 
       \node[color=uto]at (2.39,0.21){\scriptsize UT Austin\space };
 
       \node[color=utg]at (2.16,0.32){\small Travis CI\space };
 
-      \node[color=utg]at (2.49,0.42){\tiny AutoCAD\space };
+      \node[color=utg]at (2.33,0.40){\tiny Compiler Intrinsics\space };
+
+      \node[color=uto]at (1.93,0.50){\normalsize Applied Math\space };
 
       \node[color=utg]at (2.26,0.61){\scriptsize ERDC\space };
 
       \node[color=uto]at (2.65,0.90){\scriptsize Git\space };
+
+      \node[color=utg]at (2.05,1.03){\huge C/\bigCC{}\space };
 
       \node[color=uto]at (2.40,1.19){\scriptsize SMS/WMS\space };
 

--- a/one-page-resume.tex
+++ b/one-page-resume.tex
@@ -29,26 +29,26 @@
 
 %------------------------------------SUMMARY-----------------------------------%
 \section{Summary}
-Software engineer and computational scientist with 8 years of
-inter-disciplinary research and software development experience through
-15\smallplus{} projects spanning high-performance computing (HPC), applied
-mathematics, numerical methods, computational mechanics, optimization, and
-machine learning. Creator of 4 scientific software, contributor to 4 HPC
-software written in C, \CC{}, DP\CC{}, Python, and Fortran, and author of 5
-published technical documents.
+Computational scientist and software engineer with over 10 years of
+inter-disciplinary research and software development experience spanning
+high-performance computing (HPC), applied mathematics, computational
+mechanics, performance optimization, and machine learning. Creator of 4
+scientific software, contributor to 5 HPC software written in C, \CC{},
+SYCL/DP\CC{}, Python, and Fortran, and author of 5 published technical
+documents.
 
 %------------------------------PROGRAMMING SKILLS------------------------------%
 \section{Skills}
   \resumeSubItemListStart
-    \resumeSubItem{Programming}{C/\CC{}, DP\CC{}, Python, Fortran, MATLAB, Bash,
-                               MPI, OpenMP, f2py, and Python/C API.}
+    \resumeSubItem{Programming}{C/\CC{}, SYCL/DP\CC{}, Python, Fortran, MPI,
+                               OpenMP, Bash, f2py, and Python/C API.}
     \resumeSubItem{Tools}{Git, GitHub, Travis CI, CircleCI, Docker, Coveralls,
                          CMake, Make, Gcov, LCOV, Doxygen, and \LaTeX{}.}
   \resumeSubItemListEnd
 
 %------------------------------------HEADING-----------------------------------%
 %\setlength{\columnsep}{0pt}%
-\vspace{-244.4pt}
+\vspace{-242.1pt}
 %%\vspace{-162pt}
 %\vspace{-82pt}
 %\vspace{-168.25pt}
@@ -147,7 +147,7 @@ published technical documents.
 
 %\vspace{68pt}
 %\vspace{164pt}
-\vspace{228.25pt}
+\vspace{225.95pt}
 
 % Following needed since wordcloud messes up wrapping the \hrule lines
 
@@ -183,14 +183,16 @@ published technical documents.
       \resumeSubSubheading{\textbf{Intel Corporation}}{Austin, TX}
         \resumeItemListStart
           \resumeItem{Responsibilities}
-            {Owned sparse linear algebra and sparse solver components in the
+            {Owned sparse linear algebra and high-performance conjugate gradient
+            (HPCG) benchmark components as a contributor in the
             Intel\textsuperscript{\scriptsize{\textregistered}} oneAPI Math
-            Kernel Library (oneMKL) team, optimizing their performance on Intel
-            CPUs and GPUs.}
+            Kernel Library (oneMKL) team.}
           \resumeItem{Key contributions}
-            {Implemented GPU optimizations for sparse $\times$ sparse matrix
-            product for CSR format, and doubled the performance of sparse
-            $\times$ dense matrix product on CPUs for BSR format in oneMKL.}
+            {Doubled the performance of key \textbf{SYCL} APIs on GPUs, viz.,
+            sparse matrix-vector product (GEMV) and sparse $\times$ sparse
+            matrix product (matmat) for CSR format, and doubled the
+            performance of sparse $\times$ dense matrix product (GEMM) on CPUs
+            for BSR format in oneMKL.}
         \resumeItemListEnd
 
     %---------------------------------Title------------------------------------%
@@ -204,8 +206,9 @@ published technical documents.
             of post-doctoral fellows and doctoral students in the team.}
           \resumeItem{Key contribution}
             {Led the development of coupled PyTorch neural network and CFD
-            models in the Python software, Water Coupler, to potentially save
-            lives and billions of dollars through hurricane flood forecasts.}
+            models in the \textbf{Python} software, Water Coupler, to
+            potentially save lives and billions of dollars through hurricane
+            flood forecasts.}
         \resumeItemListEnd
 
     %---------------------------------Title------------------------------------%

--- a/two-page-resume.tex
+++ b/two-page-resume.tex
@@ -29,13 +29,13 @@
 
 %------------------------------------SUMMARY-----------------------------------%
 \section{Summary}
-Software engineer and computational scientist with 8 years of
-inter-disciplinary research and software development experience through
-15\smallplus{} projects spanning high-performance computing (HPC), applied
-mathematics, numerical methods, computational mechanics, optimization, and
-machine learning. Creator of 4 scientific software, contributor to 4 HPC
-software written in C, \CC{}, DP\CC{}, Python, and Fortran, and author of 5
-published technical documents.
+Computational scientist and software engineer with over 10 years of
+inter-disciplinary research and software development experience spanning
+high-performance computing (HPC), applied mathematics, computational
+mechanics, performance optimization, and machine learning. Creator of 4
+scientific software, contributor to 5 HPC software written in C, \CC{},
+SYCL/DP\CC{}, Python, and Fortran, and author of 5 published technical
+documents.
 
 %------------------------------------HEADING-----------------------------------%
 \vspace{-182.8pt}
@@ -145,16 +145,22 @@ published technical documents.
       %-------------------------------Job 5------------------------------------%
       \resumeSubSubheading{\textbf{Intel Corporation}}{Austin, TX}
         \resumeItemListStart
-          \resumeUnlabeledItem{Owned sparse linear algebra and sparse solver
-            components as a contributor in the
-            Intel\textsuperscript{\scriptsize{\textregistered}} oneAPI Math
+          \resumeUnlabeledItem{Owned sparse linear algebra and high-performance
+            conjugate gradient (HPCG) benchmark components as a contributor in
+            the Intel\textsuperscript{\scriptsize{\textregistered}} oneAPI Math
             Kernel Library (oneMKL) team.}
-          \resumeUnlabeledItem{Implemented GPU performance optimizations for the
-            newly introduced DP\CC{} API of sparse $\times$ sparse matrix
-            product for compressed sparse row (CSR) matrices in oneMKL.}
+          \resumeUnlabeledItem{Doubled the performance of sparse matrix-vector
+            product (GEMV) oneMKL SYCL API on latest Intel GPUs using SIMD
+            vectorization and prefetching techniques.}
+          \resumeUnlabeledItem{Implemented GPU performance optimizations for
+            the newly introduced sparse $\times$ sparse matrix product
+            (matmat/spGEMM) SYCL API for compressed sparse row (CSR) matrices
+            in oneMKL.}
           \resumeUnlabeledItem{Doubled the performance of block sparse row (BSR)
             matrix $\times$ row-major dense matrix product in oneMKL on CPUs
-            by implementing loop unrolling and AVX2/AVX512 compiler intrinsics.}
+            by using AVX512 compiler intrinsics.}
+          \resumeUnlabeledItem{Introduced optimized SYCL APIs in oneMKL
+            for sorting, copying and transposing CSR matrices on GPUs.}
         \resumeItemListEnd
 
     %---------------------------------Title------------------------------------%
@@ -201,17 +207,13 @@ published technical documents.
           \resumeUnlabeledItem{Created the open-source parallel Python software,
             Water Coupler, by coupling 2 CFD software of USACE, AdH and GSSHA,
             to save lives through real-time hurricane compound flood forecasts.}
-          \resumeUnlabeledItem{Developed the HPC Python interfaces of AdH and
-            GSSHA by creating and using a new open-source software, htopy, which
-            automates generation of Python wrappers of C/\CC{} software in
-            hours instead of days.}
           \resumeUnlabeledItem{Developed, tested, verified, validated,
             documented, and published coupling between 2D and 3D shallow water
             models in AdH for USACE for enabling one of the first simulations of
             flooding with 3D ocean models.}
-          \resumeUnlabeledItem{Contributed numerous physics modules to AdH for
-            USACE, including its wind library, 3D prism mesh adaption, and
-            improved parallel load rebalancing for 3D models.}
+          \resumeUnlabeledItem{Developed important physics features in AdH
+            for USACE, including its wind library, 3D prism mesh adaption,
+            and improved parallel load rebalancing in 3D models.}
        \resumeItemListEnd
 
     %---------------------------------Title------------------------------------%
@@ -240,10 +242,10 @@ published technical documents.
 \section{Select Software Contributions}
   \resumeSubItemListStart
     \resumeSubItem{Contributor -- \href{https://https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html}{Intel\textsuperscript{\scriptsize{\textregistered}} oneAPI Math Kernel Library (oneMKL)}}
-      {Owned feature implementations, CPU/GPU architecture-specific performance
-       optimizations, and bug fixes for sparse linear algebra and sparse solver
+      {Owned feature implementations and CPU/GPU architecture-specific
+       performance optimizations for sparse linear algebra and HPCG benchmark
        components in oneMKL, written in \textbf{C}, \textbf{\CC{}},
-       \textbf{DP\CC{}}, and \textbf{Fortran}.}
+       \textbf{SYCL/DP\CC{}}, and \textbf{Fortran}.}
     \resumeSubItem{Creator -- \href{https://github.com/gajanan-choudhary/water-coupler}{Water Coupler}}
       {Developed the \textbf{open-source parallel Python} software for coupling
       physics models, AdH (\textbf{C}), GSSHA (\textbf{\CC{}}), and ADCIRC
@@ -266,8 +268,8 @@ published technical documents.
 
     \resumeSubheading{Software development:}{}
       \resumeItemListStart
-        \resumeItem{Programming}{C/\CC{}, DP\CC{}, Python, Fortran, MATLAB,
-            SYCL, MPI, OpenMP, f2py, SWIG, Python/C API, and Bash.}
+        \resumeItem{Programming}{C/\CC{}, SYCL/DP\CC{}, Python, Fortran,
+            MATLAB, MPI, OpenMP, f2py, SWIG, Python/C API, and Bash.}
 
         \resumeItem{Tools}{GitHub, Bitbucket, Git, Mercurial, SVN,
             Travis CI, CircleCI, Docker, Coveralls, Codecov, CMake, GNU Make,
@@ -276,10 +278,9 @@ published technical documents.
 
         \resumeItem{Concepts}{Data structures, algorithms, complexity,
             object-oriented programming (OOP), standard template library (STL),
-            parallel programming, general
-            purpose GPU (GPGPU) programming, language interoperability,
-            continuous integration and continuous delivery (CI/CD), and
-            test-driven development (TDD).}
+            parallel programming, CPU and GPU performance optimization,
+            language interoperability, continuous integration and
+            continuous delivery (CI/CD), and test-driven development (TDD).}
       \resumeItemListEnd
 
     \resumeSubheading{Research:}{}

--- a/two-page-resume.tex
+++ b/two-page-resume.tex
@@ -48,45 +48,49 @@ documents.
 
     \begin{tinyb}
 
-      \node[color=uto]at (0.26,0.13){\footnotesize ANSYS\space };
-      
-      \node[color=uto]at (0.57,0.25){\tiny CSS\space };
+      \node[color=utg]at (0.20,0.13){\footnotesize Assembly\space };
+
+      \node[color=uto]at (0.10,0.20){\tiny Kernels\space };
+
+      \node[color=uto]at (0.57,0.25){\tiny Docker\space };
 
       \node[color=utg]at (0.17,0.34){\Large Python\space };
 
-      \node[color=uto]at (0.38,0.45){\scriptsize Matplotlib\space };
+      \node[color=uto]at (0.46,0.45){\scriptsize Sparse BLAS\space };
 
-      \node[color=utg]at (0.42,0.58){\normalsize MPI\space };
+      \node[color=utg]at (0.08,0.51){\footnotesize ANSYS\space };
 
-      \node[color=uto]at (0.29,0.88){\footnotesize Abaqus\space };
+      \node[color=utg]at (0.47,0.61){\normalsize MPI\space };
+
+      \node[color=uto]at (0.09,0.92){\scriptsize Intel Corporation\space };
 
       \node[color=utg]at (0.12,1.03){\footnotesize SWIG\space };
 
       \node[color=uto]at (0.16,1.18){\small CMake\space };
 
-      \node[color=uto]at (0.75,0.19){\normalsize Docker\space };
+      \node[color=uto]at (0.78,0.17){\large SYCL\space };
 
-      \node[color=utg]at (0.85,0.43){\footnotesize Bash\space };
+      \node[color=utg]at (0.85,0.32){\tiny GPUs\space };
 
       \node[color=uto]at (0.79,0.57){\footnotesize ctypes\space };
 
-      \node[color=utg]at (0.77,0.89){\footnotesize IIT Kharagpur\space };
+      \node[color=utg]at (0.85,0.89){\footnotesize IIT Kharagpur\space };
 
       \node[color=uto]at (0.50,1.03){\large CircleCI\space };
 
       \node[color=utg]at (0.65,1.17){\normalsize Neural Networks\space };
 
-      \node[color=uto]at (1.24,0.14){\footnotesize Image Processing\space };
+      \node[color=uto]at (1.28,0.14){\footnotesize Image Processing\space };
+
+      \node[color=utg]at (1.25,0.22){\tiny Performance optimization\space };
 
       \node[color=uto]at (1.07,0.35){\large GitHub\space };
 
-      \node[color=utg]at (1.15,0.50){\scriptsize SVN\space };
+      \node[color=utg]at (1.10,0.50){\scriptsize HPCG\space };
 
       \node[color=uto]at (1.18,1.01){\footnotesize MATLAB\space };
 
-      \node[color=uto]at (1.31,1.11){\tiny HTML\space };
-
-      \node[color=utg]at (1.51,0.22){\tiny STAAD Pro\space };
+      \node[color=uto]at (1.31,1.11){\tiny Bash\space };
 
       \node[color=utg]at (1.66,0.32){\footnotesize Coveralls\space };
 
@@ -94,29 +98,31 @@ documents.
 
       \node[color=utg]at (1.36,0.61){\small Fortran\space };
 
-      \node[color=uto]at (1.70,0.92){\normalsize AdH\space };
-      
+      \node[color=utg]at (1.60,0.87){\tiny CPUs\space };
+
+      \node[color=uto]at (1.77,0.92){\normalsize AdH\space };
+
       \node[color=utg]at (1.73,1.06){\small f2py\space };
 
       \node[color=uto]at (1.76,1.18){\scriptsize ParaView\space };
 
-      \node[color=uto]at (1.99,0.23){\scriptsize Make\space };
-
-      \node[color=uto]at (1.93,0.48){\normalsize Finite Elements\space };
-
-      \node[color=utg]at (2.05,1.03){\huge C/\bigCC{}\space };
-
       \node[color=utg]at (2.20,0.12){\footnotesize OpenMP\space };
+
+      \node[color=uto]at (2.08,0.23){\scriptsize Make\space };
 
       \node[color=uto]at (2.39,0.21){\scriptsize UT Austin\space };
 
       \node[color=utg]at (2.16,0.32){\small Travis CI\space };
 
-      \node[color=utg]at (2.49,0.42){\tiny AutoCAD\space };
+      \node[color=utg]at (2.33,0.40){\tiny Compiler Intrinsics\space };
+
+      \node[color=uto]at (1.93,0.50){\normalsize Applied Math\space };
 
       \node[color=utg]at (2.26,0.61){\scriptsize ERDC\space };
 
       \node[color=uto]at (2.65,0.90){\scriptsize Git\space };
+
+      \node[color=utg]at (2.05,1.03){\huge C/\bigCC{}\space };
 
       \node[color=uto]at (2.40,1.19){\scriptsize SMS/WMS\space };
 

--- a/wordcloud.tex
+++ b/wordcloud.tex
@@ -54,45 +54,49 @@
 
     \begin{tinyb}
 
-      \node[color=uto]at (0.26,0.13){\footnotesize ANSYS\space };
-      
-      \node[color=uto]at (0.57,0.25){\tiny CSS\space };
+      \node[color=utg]at (0.20,0.13){\footnotesize Assembly\space };
+
+      \node[color=uto]at (0.10,0.20){\tiny Kernels\space };
+
+      \node[color=uto]at (0.57,0.25){\tiny Docker\space };
 
       \node[color=utg]at (0.17,0.34){\Large Python\space };
 
-      \node[color=uto]at (0.38,0.45){\scriptsize Matplotlib\space };
+      \node[color=uto]at (0.46,0.45){\scriptsize Sparse BLAS\space };
 
-      \node[color=utg]at (0.42,0.58){\normalsize MPI\space };
+      \node[color=utg]at (0.08,0.51){\footnotesize ANSYS\space };
 
-      \node[color=uto]at (0.29,0.88){\footnotesize Abaqus\space };
+      \node[color=utg]at (0.47,0.61){\normalsize MPI\space };
+
+      \node[color=uto]at (0.09,0.92){\scriptsize Intel Corporation\space };
 
       \node[color=utg]at (0.12,1.03){\footnotesize SWIG\space };
 
       \node[color=uto]at (0.16,1.18){\small CMake\space };
 
-      \node[color=uto]at (0.75,0.19){\normalsize Docker\space };
+      \node[color=uto]at (0.78,0.17){\large SYCL\space };
 
-      \node[color=utg]at (0.85,0.43){\footnotesize Bash\space };
+      \node[color=utg]at (0.85,0.32){\tiny GPUs\space };
 
       \node[color=uto]at (0.79,0.57){\footnotesize ctypes\space };
 
-      \node[color=utg]at (0.77,0.89){\footnotesize IIT Kharagpur\space };
+      \node[color=utg]at (0.85,0.89){\footnotesize IIT Kharagpur\space };
 
       \node[color=uto]at (0.50,1.03){\large CircleCI\space };
 
       \node[color=utg]at (0.65,1.17){\normalsize Neural Networks\space };
 
-      \node[color=uto]at (1.24,0.14){\footnotesize Image Processing\space };
+      \node[color=uto]at (1.28,0.14){\footnotesize Image Processing\space };
+
+      \node[color=utg]at (1.25,0.22){\tiny Performance optimization\space };
 
       \node[color=uto]at (1.07,0.35){\large GitHub\space };
 
-      \node[color=utg]at (1.15,0.50){\scriptsize SVN\space };
+      \node[color=utg]at (1.10,0.50){\scriptsize HPCG\space };
 
       \node[color=uto]at (1.18,1.01){\footnotesize MATLAB\space };
 
-      \node[color=uto]at (1.31,1.11){\tiny HTML\space };
-
-      \node[color=utg]at (1.51,0.22){\tiny STAAD Pro\space };
+      \node[color=uto]at (1.31,1.11){\tiny Bash\space };
 
       \node[color=utg]at (1.66,0.32){\footnotesize Coveralls\space };
 
@@ -100,29 +104,31 @@
 
       \node[color=utg]at (1.36,0.61){\small Fortran\space };
 
-      \node[color=uto]at (1.70,0.92){\normalsize AdH\space };
-      
+      \node[color=utg]at (1.60,0.87){\tiny CPUs\space };
+
+      \node[color=uto]at (1.77,0.92){\normalsize AdH\space };
+
       \node[color=utg]at (1.73,1.06){\small f2py\space };
 
       \node[color=uto]at (1.76,1.18){\scriptsize ParaView\space };
 
-      \node[color=uto]at (1.99,0.23){\scriptsize Make\space };
-
-      \node[color=uto]at (1.93,0.48){\normalsize Finite Elements\space };
-
-      \node[color=utg]at (2.05,1.03){\huge C/\bigCC{}\space };
-
       \node[color=utg]at (2.20,0.12){\footnotesize OpenMP\space };
+
+      \node[color=uto]at (2.08,0.23){\scriptsize Make\space };
 
       \node[color=uto]at (2.39,0.21){\scriptsize UT Austin\space };
 
       \node[color=utg]at (2.16,0.32){\small Travis CI\space };
 
-      \node[color=utg]at (2.49,0.42){\tiny AutoCAD\space };
+      \node[color=utg]at (2.33,0.40){\tiny Compiler Intrinsics\space };
+
+      \node[color=uto]at (1.93,0.50){\normalsize Applied Math\space };
 
       \node[color=utg]at (2.26,0.61){\scriptsize ERDC\space };
 
       \node[color=uto]at (2.65,0.90){\scriptsize Git\space };
+
+      \node[color=utg]at (2.05,1.03){\huge C/\bigCC{}\space };
 
       \node[color=uto]at (2.40,1.19){\scriptsize SMS/WMS\space };
 


### PR DESCRIPTION
This merge does following changes:
* CV.bib is updated to reflect submitted/under-review papers
* In all LaTex resume files:
  - Update wordcloud: add new words, remove some, and rearrange
* In all LaTex resume files and README.md:
  - Update the summary
  - Update Intel experience
  - Replace DPC++ with SYCL/DPC++
  - Minor textual rephrases
* In the two-page resume:
  - Remove `htopy` bullet to make space
